### PR TITLE
feat: Mark operator as singleton

### DIFF
--- a/kapeta.yml
+++ b/kapeta.yml
@@ -312,6 +312,7 @@ spec:
                                 type: boolean
   local:
     image: rabbitmq:3.12.12-management-alpine
+    singleton: true
     ports:
       amqp:
         port: 5672


### PR DESCRIPTION
Will cause local-cluster-service to only start 1 per plan